### PR TITLE
Fix base62 error and add Ascii85

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 **BaseCrack** is a tool written in Python that can decode all alphanumeric base encoding schemes. This tool can accept single user input, multiple inputs from a file, input from argument, **multi-encoded bases** and decode them incredibly fast.
 
-Decode Base16, Base32, Base36, Base58, Base62, Base64, Base64Url, Base85, Base91, Base92 and more with the best base encoding scheme decoding tool in town. It's useful for **CTFs**, **Bug Bounty Hunting**, and **Cryptography**.
+Decode Base16, Base32, Base36, Base58, Base62, Base64, Base64Url, Base85, Ascii85, Base91, Base92 and more with the best base encoding scheme decoding tool in town. It's useful for **CTFs**, **Bug Bounty Hunting**, and **Cryptography**.
 
 **What's new in v1.1:** I heard your feature requests, now you can generate a wordlist/output with the decoded bases! :)
 

--- a/basecrack.py
+++ b/basecrack.py
@@ -95,7 +95,7 @@ class BaseCrack:
 
             # decoding as base62
             try:
-                base62_decode = base62.encode(int(encoded_base)).decode('utf-8', 'replace')
+                base62_decode = base62.decodebytes(encoded_base).decode('utf-8', 'replace')
                 if not contains_replacement_char(base62_decode):
                     encoding_type.append('Base62')
                     results.append(base62_decode)

--- a/basecrack.py
+++ b/basecrack.py
@@ -137,6 +137,17 @@ class BaseCrack:
             except:
                 pass
 
+            # decoding as ascii85
+            try:
+                ascii85_decode = base64.a85decode(encoded_base).decode('utf-8', 'replace')
+                if not contains_replacement_char(ascii85_decode):
+                    encoding_type.append('Ascii85')
+                    results.append(ascii85_decode)
+                    if not self.api_call:
+                        print(colored('\n[>] Decoding as Ascii85: ', 'blue') + colored(ascii85_decode, 'green'))
+            except:
+                pass
+
             # decoding as base91
             try:
                 base91_decode = base91.decode(encoded_base).decode('utf-8', 'replace')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ colorama
 termcolor
 base36
 base58
-base-62
+pybase62
 base91


### PR DESCRIPTION
This fixes https://github.com/mufeedvh/basecrack/issues/4#issue-700623958 by replacing `base-62` with `pybase62`. Uninstalling the old dependency before installing the new dependency is required.

It also adds support for Ascii85 encoding.